### PR TITLE
게시판 API 만들기 - DATA REST 적용 및 테스트 정의

### DIFF
--- a/board/build.gradle
+++ b/board/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/board/src/main/java/org/daffy3/board/domain/Article.java
+++ b/board/src/main/java/org/daffy3/board/domain/Article.java
@@ -4,13 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/board/src/main/java/org/daffy3/board/domain/ArticleComment.java
+++ b/board/src/main/java/org/daffy3/board/domain/ArticleComment.java
@@ -4,13 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter

--- a/board/src/main/java/org/daffy3/board/repository/ArticleCommentRepository.java
+++ b/board/src/main/java/org/daffy3/board/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package org.daffy3.board.repository;
 
 import org.daffy3.board.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/board/src/main/java/org/daffy3/board/repository/ArticleRepository.java
+++ b/board/src/main/java/org/daffy3/board/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package org.daffy3.board.repository;
 
 import org.daffy3.board.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/board/src/main/resources/application.yaml
+++ b/board/src/main/resources/application.yaml
@@ -31,3 +31,7 @@ spring:
   sql:
     init:
       mode: always
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated

--- a/board/src/test/java/org/daffy3/board/controller/DataRestTest.java
+++ b/board/src/test/java/org/daffy3/board/controller/DataRestTest.java
@@ -1,0 +1,50 @@
+package org.daffy3.board.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mockMvc;
+
+    public DataRestTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @DisplayName("[API] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Given
+        mockMvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[API] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnArticleJsonResponse() throws Exception {
+        // Given
+
+        // When & Given
+        mockMvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+}


### PR DESCRIPTION
게시판, 게시글, 댓글 데이터는 간편하게 Spring DATA REST로 서비스하고, 해당  api들의 존재 여부만 체크하게끔 통합테스트 작성